### PR TITLE
ガイダンス修正

### DIFF
--- a/app/v2/calendar.rb
+++ b/app/v2/calendar.rb
@@ -16,7 +16,9 @@ class Calendar
     def shifts_tomorrow
       events.map { |event|
         CalendarItem.new(calendar_name: event.summary,
-                         start_time: event.start.date_time, end_time: event.end.date_time)
+                         start_time:    event.start.date_time,
+                         end_time:      event.end.date_time,
+                         email:         event.organizer.email)
       }.select(&:tomorrow_shift?)
     end
 

--- a/app/v2/calendar_item.rb
+++ b/app/v2/calendar_item.rb
@@ -18,7 +18,7 @@ class CalendarItem
   # Return the formatted start time.
   # @return string
   def str_start_time
-    @start_time.strftime('%Y:%m:%d %H:%M:%S') if @start_time.present?
+    @start_time.strftime('%Y:%m:%d %H:%M') if @start_time.present?
   end
 
   # Return a mentor who is a participant of this calendar item.

--- a/app/v2/calendar_item.rb
+++ b/app/v2/calendar_item.rb
@@ -4,20 +4,21 @@ require_relative './mentor_registry'
 
 # Data object to wrap and carry an item originally from Google Calendar.
 class CalendarItem
-  attr_accessor :calendar_name, :start_time, :end_time
+  attr_accessor :calendar_name, :start_time, :end_time, :email
 
   # Constructor
   # @return CalendarItem
-  def initialize(calendar_name:, start_time:, end_time:)
+  def initialize(calendar_name:, start_time:, end_time:, email:)
     @calendar_name = calendar_name
     @start_time    = start_time
     @end_time      = end_time
+    @email         = email
   end
 
   # Return the formatted start time.
   # @return string
   def str_start_time
-    @start_time.strftime('%Y:%m:%d %H-%M-%S') if @start_time.present?
+    @start_time.strftime('%Y:%m:%d %H:%M:%S') if @start_time.present?
   end
 
   # Return a mentor who is a participant of this calendar item.
@@ -29,20 +30,14 @@ class CalendarItem
   # Checks if the calendar_item is for guidance
   # @return boolean
   def guidance?
-    @calendar_name.include?('ガイダンス')
-  end
-
-  # Checks if the calendar_item is for counseling
-  # @return boolean
-  def counseling?
-    @calendar_name.include?('面談')
+    @email == ENV['GUIDANCE_EMAIL']
   end
 
   # Get the mentor who is in charged of the guidance item on the calendar.
   # This method rejects guidance item itself.
   # @return CalendarItem
   def guidance_mentor_item?(calendar_item:)
-    calendar_item.start_time.between?(self.start_time, self.end_time) && !guidance? && !counseling?
+    self.start_time >= calendar_item.start_time && self.end_time > calendar_item.end_time
   end
 
   # Checks if calendar_item is a tomorrow_shift

--- a/app/v2/main_script.rb
+++ b/app/v2/main_script.rb
@@ -12,7 +12,7 @@ Dotenv.overload
 
 shifts_tomorrow = Calendar.shifts_tomorrow
 
-if shifts_tomorrow.blank? || shifts_tomorrow.none?(&:guidance?) || shifts_tomorrow.none?(&:counseling?)
+if shifts_tomorrow.blank? || shifts_tomorrow.none?(&:guidance?)
   return SlackForNotification.sends_no_guidance_notification
 end
 
@@ -25,9 +25,9 @@ begin
       )
     end
 
-    if calendar_item.guidance? || calendar_item.counseling?
-      guidance_mentor_items = shifts_tomorrow.select{ |tomorrow_shift|
-        tomorrow_shift.guidance_mentor_item?(calendar_item: calendar_item)
+    if calendar_item.guidance?
+      guidance_mentor_items = shifts_tomorrow.select{ |shift_tomorrow|
+        shift_tomorrow.guidance_mentor_item?(calendar_item: calendar_item)
       }
 
       guidance_mentor_items.each do |guidance_mentor_item|


### PR DESCRIPTION
## WHY
 - ガイダンス通知で、ガイダンスの予定がどうかを「面談」という言葉で判断していたが、文字コードとかの関係でうまく読み込まれないときがあったため、ある特定のサブカレンダーで登録されているかで判断するようにした。

## WHAT
 - `Calendar` から `calendar_item` オブジェクト作成時に、`email`を引っ張ってくるようにした。
 - `guidance?` メソッドの中身を、 `calendar_item` オブジェクトの `email` が特定のカレンダーかどうかで判断した。